### PR TITLE
Add hostname to message fields

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ class GoodHapiGraylog extends Stream.Writable {
       this.write();
     });
     this.log = log.setConfig({
-      fields: { facility },
+      fields: { facility, host:hostname },
       adapterName: adapter,
       adapterOptions: {
         host,


### PR DESCRIPTION
Hi,
First - I want to thank you for this project! We are using it since several months to deliver our node logs to our Graylog instance. 

After we updated to the latest version, we noticed that our messages in Graylog don't contain the correct `source` field anymore, breaking messages routing and other rules. 

The `source` value comes from the `host` (`hostname`) field in the payload. And indeed, the `host` was removed in this commit: https://github.com/gleip/good-hapi-graylog2/commit/1a02514d7cbd010fc4c2301294b18d6dc3b801b7, leaving the `hostname` parameter unused. The underlying logging library then provides a [default](https://github.com/kkamkou/node-gelf-pro/blob/master/lib/gelf-pro.js#L83) host name which is in our case a docker container ID, not the explicitly set `hostname`.

If I return the `host` field back, everything works as before. 

Could you please check my pull request and consider merging it?

Thank you,
Tomas